### PR TITLE
Add optional serde serialization and deserialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,4 @@ jobs:
             - name: Run Miri
               run: |
                   cargo miri setup
-                  cargo miri test -- -Zmiri-disable-isolation -- --skip proptest
+                  cargo miri test -- -Zmiri-disable-isolation -- --skip proptest --skip ser_de

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ name = "smartstring"
 harness = false
 
 [features]
-test = ["arbitrary"]
+test = ["arbitrary", "serde"]
 
 [dependencies]
 static_assertions = "1.1.0"
+serde = { version = "1", optional = true }
 arbitrary = { version = "0.4", optional = true, features = ["derive"] }
 
 [dev-dependencies]
@@ -28,3 +29,4 @@ proptest = "0.10"
 proptest-derive = "0.2"
 criterion = "0.3.2"
 rand = "0.7.3"
+serde_test = "1"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ when not inlined it's pointer compatible with `String`, meaning that you can saf
 if it had never been a `SmartString`. (But please don't do that, there's an `Into<String>`
 implementation that's much safer.)
 
+## Serialization
+
+Serde support is optional and can be enabled with the `serde` feature.
+
 ## Documentation
 
 -   [API docs](https://docs.rs/smartstring)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@
 //! memory efficient in these cases. There will always be a slight overhead on all
 //! operations on boxed strings, compared to [`String`][String].
 //!
+//! ## Serialization
+//! [Serde][serde] support is optional and can be enabled with the `serde` feature.
+//!
 //! [SmartString]: struct.SmartString.html
 //! [LazyCompact]: struct.LazyCompact.html
 //! [Compact]: struct.Compact.html
@@ -93,6 +96,7 @@
 //! [cmp]: https://doc.rust-lang.org/std/cmp/trait.Ord.html#tymethod.cmp
 //! [transmute]: https://doc.rust-lang.org/std/mem/fn.transmute.html
 //! [tinystr]: https://crates.io/crates/tinystr
+//! [serde]: https://crates.io/crates/serde
 
 #![forbid(rust_2018_idioms)]
 #![deny(nonstandard_style)]
@@ -131,6 +135,9 @@ use casts::{StringCast, StringCastInto, StringCastMut};
 
 mod iter;
 pub use iter::Drain;
+
+#[cfg(feature = "serde")]
+mod serde;
 
 /// Convenient type aliases.
 pub mod alias {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,51 @@
+use crate::{SmartString, SmartStringMode};
+use std::{fmt, marker::PhantomData};
+
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+impl<T: SmartStringMode> Serialize for SmartString<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self)
+    }
+}
+
+impl<'de, T: SmartStringMode> Deserialize<'de> for SmartString<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_string(SmartStringVisitor(PhantomData))
+            .map(SmartString::from)
+    }
+}
+
+struct SmartStringVisitor<T: SmartStringMode>(PhantomData<*const T>);
+
+impl<'de, T: SmartStringMode> Visitor<'de> for SmartStringVisitor<T> {
+    type Value = SmartString<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(SmartString::from(v))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(SmartString::from(v))
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -493,4 +493,20 @@ mod tests {
         assert_eq!(control_smart, string);
         assert_eq!(Ordering::Equal, string.cmp(&control_smart));
     }
+
+    #[test]
+    fn test_ser_de() {
+        use serde_test::{assert_tokens, Token};
+
+        let strings = [
+            "",
+            "small test",
+            "longer than inline string for serde testing",
+        ];
+
+        for &string in strings.iter() {
+            let value = SmartString::<Compact>::from(string);
+            assert_tokens(&value, &[Token::String(string)]);
+        }
+    }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -494,6 +494,7 @@ mod tests {
         assert_eq!(Ordering::Equal, string.cmp(&control_smart));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_ser_de() {
         use serde_test::{assert_tokens, Token};


### PR DESCRIPTION
As mentioned on twitter, here's the straight-forward impl of serde :)

The only thing to note is that `deserialize_string` is used (and `visit_string` implemented) instead of `deserialize_str` to give the possibility of directly passing through a `String` if the deserializer used happens to have an owned `String` anyways.