### PR TITLE
Implement std::fmt::Display

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ use std::{
     borrow::{Borrow, BorrowMut},
     cmp::Ordering,
     convert::Infallible,
-    fmt::{Debug, Error, Formatter, Write},
+    fmt::{Debug, Display, Error, Formatter, Write},
     hash::{Hash, Hasher},
     iter::FromIterator,
     mem::{forget, MaybeUninit},
@@ -1015,12 +1015,6 @@ impl<Mode: SmartStringMode> Into<String> for SmartString<Mode> {
     }
 }
 
-impl<Mode: SmartStringMode> ToString for SmartString<Mode> {
-    fn to_string(&self) -> String {
-        self.as_str().to_string()
-    }
-}
-
 impl<Mode: SmartStringMode> PartialEq<str> for SmartString<Mode> {
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
@@ -1086,6 +1080,12 @@ impl<Mode: SmartStringMode> Hash for SmartString<Mode> {
 impl<Mode: SmartStringMode> Debug for SmartString<Mode> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl<Mode: SmartStringMode> Display for SmartString<Mode> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        Display::fmt(self.as_str(), f)
     }
 }
 


### PR DESCRIPTION
Currently, SmartString only implements `std::fmt::Debug`. This makes it difficult to use as a drop-in replacement for `String`, especially in `format_args` contexts such as `println`:
```
use smartstring::alias::String;

let s = String::from("hello");
println!("{}", s);
```

This adds in a simple implementation of `std::fmt::Display`. This also removes the manual implementation of `std::string::ToString`, as that has a conflicting blanket implementation for types that implement `Display`.