### PR TITLE
New implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### ADDED
+-   `SmartString` now supports null pointer optimizations. `Option<SmartString>` is now the same size as `SmartString`.
+-   A feature flag `lazy_null_pointer_optimizations`, which enables null pointer optimizations for `SmartString<LazyCompact>`. On by default.
+
+### FIXED
+-   `SmartString` now uses the size or capacity field to store the discriminant bit, instead of relying on pointer alignment (#4)
+-   `SmartString` doesn't rely on the internal layout of `String` (#4)
+
 ## [0.2.3] - 2020-07-07
 
 ### ADDED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] - 2020-07-07
 
 ### ADDED
 
+-   `SmartString` now implements `Display`. (#6)
 -   `SmartString` now implements `FromIterator<char>`.
 -   Support for [`serde`](https://serde.rs/) behind the `serde` feature flag. (#2)
 -   Support for [`arbitrary`](https://crates.io/crates/arbitrary) behind the `arbitrary` feature
     flag.
 -   Support for [`proptest`](https://crates.io/crates/proptest) behind the `proptest` feature flag.
+
+### FIXED
+
+-   `SmartString::push_str` would previously trigger two heap allocations while promoting an inline
+    string to a boxed string, one of which was unnecessary. It now only makes the one strictly
+    necessary allocation. (#5)
+-   Fixed a bug where `SmartString::remove` would panic if you tried to remove the last index in an
+    inline string.
 
 ## [0.2.2] - 2020-07-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartstring"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Bodil Stokke <bodil@bodil.org>"]
 edition = "2018"
 license = "MPL-2.0+"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ name = "smartstring"
 harness = false
 
 [features]
+default = ["lazy_null_pointer_optimizations"]
 test = ["arbitrary", "arbitrary/derive"]
+lazy_null_pointer_optimizations = []
 
 [dependencies]
 static_assertions = "1.1.0"

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -98,7 +98,7 @@ impl BoxedString for PseudoString {
     }
 
     fn capacity(&self) -> usize {
-        usize::from(self.capacity) << 1 >> 1
+        usize::from(self.capacity)
     }
 }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -2,55 +2,151 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cmp::Ordering;
+use std::ops::{Deref, DerefMut};
+use crate::{SmartStringMode, SmartString, inline::InlineString};
 
-pub trait BoxedString {
-    fn string(&self) -> &String;
-    fn string_mut(&mut self) -> &mut String;
-    fn into_string(self) -> String;
+pub trait BoxedString: Deref<Target = str> + DerefMut + Into<String> {
+    //This is unsafe when null pointer optimizations are used
+    //Then, it is unsound if the capacity of the string is 0
+    unsafe fn from_string_unchecked(string: String) -> Self;
+    fn capacity(&self) -> usize;
+}
 
-    fn cmp_with_str(&self, other: &str) -> Ordering;
-    fn cmp_with_self(&self, other: &Self) -> Ordering;
-    fn eq_with_str(&self, other: &str) -> bool;
-    fn eq_with_self(&self, other: &Self) -> bool;
+//Just a string, but the fields are in fixed order
+#[cfg(target_endian = "big")]
+#[repr(C)]
+#[derive(Debug)]
+pub struct PseudoString {
+    capacity: usize,
+    ptr: std::ptr::NonNull<u8>,
+    size: usize,
+}
 
-    fn len(&self) -> usize {
-        self.string().len()
+#[cfg(target_endian = "little")]
+#[cfg(not(feature = "lazy_null_pointer_optimizations"))]
+#[repr(C)]
+//This seems to be the most common arrangement of std::String
+//However, with lazy null pointer optimizations, this arrangement does not work
+#[derive(Debug)]
+pub struct PseudoString {
+    ptr: std::ptr::NonNull<u8>,
+    capacity: usize,
+    size: usize,
+}
+
+#[cfg(target_endian = "little")]
+#[cfg(feature = "lazy_null_pointer_optimizations")]
+#[repr(C)]
+#[derive(Debug)]
+pub struct PseudoString {
+    ptr: std::ptr::NonNull<u8>,
+    size: usize,
+    capacity: std::num::NonZeroUsize,
+}
+
+impl Deref for PseudoString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        unsafe {
+            let slice = std::slice::from_raw_parts(self.ptr.as_ptr().cast(), self.size);
+            std::str::from_utf8_unchecked(slice)
+        }
     }
 }
 
-impl BoxedString for String {
+impl DerefMut for PseudoString {
+    fn deref_mut(&mut self) -> &mut str {
+        unsafe {
+            let slice = std::slice::from_raw_parts_mut(self.ptr.as_ptr().cast(), self.size);
+            std::str::from_utf8_unchecked_mut(slice)
+        }
+    }
+}
+
+impl From<PseudoString> for String {
     #[inline(always)]
-    fn string(&self) -> &String {
-        self
+    fn from(string: PseudoString) -> Self {
+        unsafe {
+            String::from_raw_parts(string.ptr.as_ptr(), string.size, usize::from(string.capacity))
+        }
+    }
+}
+
+
+#[cfg(feature = "lazy_null_pointer_optimizations")]
+unsafe fn to_capacity(size: usize) -> std::num::NonZeroUsize  {
+    std::num::NonZeroUsize::new_unchecked(size)
+}
+
+#[cfg(not(feature = "lazy_null_pointer_optimizations"))]
+fn to_capacity(size: usize) -> usize  {
+    size
+}
+
+impl BoxedString for PseudoString {
+    unsafe fn from_string_unchecked(mut string: String) -> Self {
+        //into_raw_parts is nightly at the time of writing
+        //In the future the following code should be replaced with
+        //let (ptr, size, capacity) = string.into_raw_parts();
+        let capacity = string.capacity();
+        let bytes = string.as_mut_str();
+        let ptr = bytes.as_mut_ptr();
+        let size = bytes.len();
+        std::mem::forget(string);
+
+        Self {ptr: std::ptr::NonNull::new_unchecked(ptr), size, capacity: to_capacity(capacity)}
     }
 
-    #[inline(always)]
-    fn string_mut(&mut self) -> &mut String {
-        self
+    fn capacity(&self) -> usize {
+        usize::from(self.capacity) << 1 >> 1
     }
+}
 
-    fn into_string(self) -> String {
-        self
+#[derive(Debug)]
+pub(crate) struct StringReference<'a, Mode: SmartStringMode> {
+    referrant: &'a mut SmartString<Mode>,
+    string: String,
+}
+
+impl<'a, Mode: SmartStringMode> StringReference<'a, Mode> {
+    //Safety: Discriminant must be boxed
+    pub(crate) unsafe fn from_smart_unchecked(smart: &'a mut SmartString<Mode>) -> Self {
+        debug_assert_eq!(smart.discriminant(), crate::marker_byte::Discriminant::Boxed);
+        let boxed : Mode::BoxedString = std::mem::transmute_copy(smart);
+        let string = boxed.into();
+        Self {
+            referrant: smart,
+            string
+        }
     }
+}
 
-    #[inline(always)]
-    fn cmp_with_str(&self, other: &str) -> Ordering {
-        self.as_str().cmp(other)
+impl<'a, Mode: SmartStringMode> Drop for StringReference<'a, Mode> {
+    fn drop(&mut self) {
+        let string = std::mem::replace(&mut self.string, String::new());
+        if (Mode::DEALLOC && string.len() <= Mode::MAX_INLINE) || (!Mode::DEALLOC && cfg!(lazy_null_pointer_optimizations) && string.capacity() == 0) {
+            let transmuted = (self as *mut Self).cast();
+            unsafe {
+                std::ptr::write(*transmuted, InlineString::<Mode>::from(string.as_bytes()));
+            }
+        } else {
+            let transmuted = (self as *mut Self).cast();
+            unsafe {
+                std::ptr::write(*transmuted, Mode::BoxedString::from_string_unchecked(string));
+            }
+        }
     }
+}
 
-    #[inline(always)]
-    fn cmp_with_self(&self, other: &Self) -> Ordering {
-        self.cmp(other)
+impl<'a, Mode: SmartStringMode> Deref for StringReference<'a, Mode> {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.string
     }
+}
 
-    #[inline(always)]
-    fn eq_with_str(&self, other: &str) -> bool {
-        self == other
-    }
-
-    #[inline(always)]
-    fn eq_with_self(&self, other: &Self) -> bool {
-        self == other
+impl<'a, Mode: SmartStringMode> DerefMut for StringReference<'a, Mode> {
+    fn deref_mut(&mut self) -> &mut String {
+        &mut self.string
     }
 }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 use crate::{SmartStringMode, SmartString, inline::InlineString};
 
 pub trait BoxedString: Deref<Target = str> + DerefMut + Into<String> {
-    //This is unsafe when null pointer optimizations are used
+    //This is unsafe when null pointer optimizations are used with LazyCompact
     //Then, it is unsound if the capacity of the string is 0
     unsafe fn from_string_unchecked(string: String) -> Self;
     fn capacity(&self) -> usize;
@@ -25,9 +25,9 @@ pub struct PseudoString {
 #[cfg(target_endian = "little")]
 #[cfg(not(feature = "lazy_null_pointer_optimizations"))]
 #[repr(C)]
+#[derive(Debug)]
 //This seems to be the most common arrangement of std::String
 //However, with lazy null pointer optimizations, this arrangement does not work
-#[derive(Debug)]
 pub struct PseudoString {
     ptr: std::ptr::NonNull<u8>,
     capacity: usize,

--- a/src/casts.rs
+++ b/src/casts.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{inline::InlineString, SmartStringMode, boxed::StringReference};
+use crate::{boxed::StringReference, inline::InlineString, SmartStringMode};
 
 pub(crate) enum StringCast<'a, Mode: SmartStringMode> {
     Boxed(&'a Mode::BoxedString),

--- a/src/casts.rs
+++ b/src/casts.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{inline::InlineString, SmartStringMode};
+use crate::{inline::InlineString, SmartStringMode, boxed::StringReference};
 
 pub(crate) enum StringCast<'a, Mode: SmartStringMode> {
     Boxed(&'a Mode::BoxedString),
@@ -10,11 +10,19 @@ pub(crate) enum StringCast<'a, Mode: SmartStringMode> {
 }
 
 pub(crate) enum StringCastMut<'a, Mode: SmartStringMode> {
-    Boxed(&'a mut Mode::BoxedString),
+    Boxed(StringReference<'a, Mode>),
     Inline(&'a mut InlineString<Mode>),
 }
 
 pub(crate) enum StringCastInto<Mode: SmartStringMode> {
     Boxed(Mode::BoxedString),
     Inline(InlineString<Mode>),
+}
+
+//Same as transmute, except it doesn't check for same size
+//This should be replaced when it's possible to constrain the sizes of generic associated types
+pub(crate) unsafe fn please_transmute<A, B>(from: A) -> B {
+    let ret = std::mem::transmute_copy(&from);
+    std::mem::forget(from);
+    ret
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,17 +81,21 @@ pub trait DiscriminantContainer {
     /// Return Self with the requirement that the marker is inside
     fn new(marker: u8) -> Self;
     /// Flip the highest bit of marker
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure this doesn't cause UB, for example by turning a Non-zero DiscriminantContainer into a zeroed one
     unsafe fn flip_bit(&mut self);
 }
 
 impl DiscriminantContainer for std::num::NonZeroUsize {
     fn get_full_marker(&self) -> u8 {
-        (self.get() >> (std::mem::size_of::<usize>() - 1)*8) as u8
+        (self.get() >> ((std::mem::size_of::<usize>() - 1)*8)) as u8
     }
     fn new(marker: u8) -> Self {
         unsafe {
             Self::new_unchecked(
-                ((marker as usize) << (std::mem::size_of::<usize>() - 1)*8) + 1
+                ((marker as usize) << ((std::mem::size_of::<usize>() - 1)*8)) + 1
             )
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{boxed::{BoxedString, PseudoString}, inline::InlineString, SmartString};
+use crate::{
+    boxed::{BoxedString, PseudoString},
+    inline::InlineString,
+    SmartString,
+};
 use static_assertions::{assert_eq_size, const_assert, const_assert_eq};
 use std::mem::{align_of, size_of, MaybeUninit};
 
@@ -90,13 +94,11 @@ pub trait DiscriminantContainer {
 
 impl DiscriminantContainer for std::num::NonZeroUsize {
     fn get_full_marker(&self) -> u8 {
-        (self.get() >> ((std::mem::size_of::<usize>() - 1)*8)) as u8
+        (self.get() >> ((std::mem::size_of::<usize>() - 1) * 8)) as u8
     }
     fn new(marker: u8) -> Self {
         unsafe {
-            Self::new_unchecked(
-                ((marker as usize) << ((std::mem::size_of::<usize>() - 1)*8)) + 1
-            )
+            Self::new_unchecked(((marker as usize) << ((std::mem::size_of::<usize>() - 1) * 8)) + 1)
         }
     }
     unsafe fn flip_bit(&mut self) {
@@ -134,7 +136,7 @@ impl DiscriminantContainer for PossiblyZeroSize {
         }
     }
     unsafe fn flip_bit(&mut self) {
-        self.marker^= 128;
+        self.marker ^= 128;
     }
 }
 
@@ -144,7 +146,6 @@ unsafe impl SmartStringMode for Compact {
     const DEALLOC: bool = true;
     type DiscriminantContainer = std::num::NonZeroUsize;
 }
-
 
 #[cfg(not(feature = "lazy_null_pointer_optimizations"))]
 unsafe impl SmartStringMode for LazyCompact {

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,7 +108,7 @@ impl DiscriminantContainer for std::num::NonZeroUsize {
 #[cfg(target_endian = "big")]
 #[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
 #[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
-struct PossiblyZeroSize {
+pub struct PossiblyZeroSize {
     marker: u8,
     data: [MaybeUninit<u8>; std::mem::size_of::<usize>() - 1],
 }

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -5,9 +5,9 @@
 use crate::SmartStringMode;
 use std::{
     mem::MaybeUninit,
+    ops::{Deref, DerefMut},
     slice::{from_raw_parts, from_raw_parts_mut},
     str::{from_utf8_unchecked, from_utf8_unchecked_mut},
-    ops::{Deref, DerefMut},
 };
 
 #[cfg(target_endian = "big")]
@@ -15,7 +15,7 @@ use std::{
 #[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
 pub(crate) struct InlineString<Mode: SmartStringMode> {
     pub(crate) marker: u8,
-    pub(crate) data: [MaybeUninit<u8>; 3*std::mem::size_of::<usize>() - 1],
+    pub(crate) data: [MaybeUninit<u8>; 3 * std::mem::size_of::<usize>() - 1],
     phantom: std::marker::PhantomData<*const Mode>,
 }
 
@@ -23,7 +23,7 @@ pub(crate) struct InlineString<Mode: SmartStringMode> {
 #[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
 #[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
 pub(crate) struct InlineString<Mode: SmartStringMode> {
-    pub(crate) data: [MaybeUninit<u8>; 3*std::mem::size_of::<usize>() - 1],
+    pub(crate) data: [MaybeUninit<u8>; 3 * std::mem::size_of::<usize>() - 1],
     pub(crate) marker: u8,
     phantom: std::marker::PhantomData<*const Mode>,
 }
@@ -59,7 +59,7 @@ impl<Mode: SmartStringMode> InlineString<Mode> {
     pub(crate) fn new() -> Self {
         let mut ret = Self {
             marker: 128,
-            data: [MaybeUninit::uninit(); 3*std::mem::size_of::<usize>() - 1],
+            data: [MaybeUninit::uninit(); 3 * std::mem::size_of::<usize>() - 1],
             phantom: std::marker::PhantomData,
         };
         //Are nullptr optimizations on?
@@ -67,7 +67,7 @@ impl<Mode: SmartStringMode> InlineString<Mode> {
             //Initialize the 7 highest bytes of data
             for j in 0..(std::mem::size_of::<usize>() - 1) {
                 #[cfg(target_endian = "little")]
-                let j = 3*std::mem::size_of::<usize>() - 3 - j;
+                let j = 3 * std::mem::size_of::<usize>() - 3 - j;
 
                 ret.data[j] = MaybeUninit::zeroed();
             }

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -2,17 +2,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{marker_byte::Marker, SmartStringMode};
+use crate::SmartStringMode;
 use std::{
     mem::MaybeUninit,
     slice::{from_raw_parts, from_raw_parts_mut},
     str::{from_utf8_unchecked, from_utf8_unchecked_mut},
 };
 
-#[repr(C)]
+#[cfg(target_endian = "big")]
+#[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
+#[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
 pub(crate) struct InlineString<Mode: SmartStringMode> {
-    pub(crate) marker: Marker,
-    pub(crate) data: Mode::InlineArray,
+    pub(crate) marker: u8,
+    pub(crate) data: [MaybeUninit<u8>; 3*std::mem::size_of::<usize>() - 1],
+    phantom: std::marker::PhantomData<*const Mode>,
+}
+
+#[cfg(target_endian = "little")]
+#[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
+#[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
+pub(crate) struct InlineString<Mode: SmartStringMode> {
+    pub(crate) data: [MaybeUninit<u8>; 3*std::mem::size_of::<usize>() - 1],
+    pub(crate) marker: u8,
+    phantom: std::marker::PhantomData<*const Mode>,
 }
 
 impl<Mode: SmartStringMode> Clone for InlineString<Mode> {
@@ -25,90 +37,107 @@ impl<Mode: SmartStringMode> Copy for InlineString<Mode> {}
 
 impl<Mode: SmartStringMode> InlineString<Mode> {
     pub(crate) fn new() -> Self {
-        Self {
-            marker: Marker::new_inline(0),
-            data: unsafe { MaybeUninit::zeroed().assume_init() },
+        let mut ret = Self {
+            marker: 128,
+            data: [MaybeUninit::uninit(); 3*std::mem::size_of::<usize>() - 1],
+            phantom: std::marker::PhantomData,
+        };
+        //Are nullptr optimizations on?
+        if Mode::DEALLOC || cfg!(lazy_null_pointer_optimizations) {
+            //Initialize the 7 first or last bytes of data
+            for j in 0..(std::mem::size_of::<usize>() - 1) {
+                #[cfg(target_endian = "little")]
+                let j = 3*std::mem::size_of::<usize>() - 3 - j;
+
+                ret.data[j] = MaybeUninit::zeroed();
+            }
         }
+        ret
     }
 
-    pub(crate) fn set_size(&mut self, size: usize) {
-        self.marker.set_data(size as u8);
+    //len must be less than Mode::MAX_INLINE
+    //If growing, the newly avaliable bytes should be visible
+    pub(crate) unsafe fn set_len(&mut self, len: usize) {
+        debug_assert!(len <= Mode::MAX_INLINE);
+        self.marker = 128 | len as u8
     }
 
     pub(crate) fn len(&self) -> usize {
-        let len = self.marker.data() as usize;
-        // Panic immediately if inline length is too high, which suggests
-        // assumptions made about `String`'s memory layout are invalid.
-        assert!(len <= Mode::MAX_INLINE);
+        let len = self.marker as usize & 127;
+        debug_assert!(len <= Mode::MAX_INLINE);
         len
     }
 
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-
-    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
+    //Caller is responsible for keeping the utf-8 encoded string working
+    pub(crate) unsafe fn as_mut_slice(&mut self) -> &mut [MaybeUninit<u8>] {
         self.data.as_mut()
     }
 
     pub(crate) fn as_str(&self) -> &str {
         unsafe {
-            let data = from_raw_parts(self.data.as_ref().as_ptr(), self.len());
+            let data = from_raw_parts(self.data.as_ref().as_ptr().cast(), self.len());
             from_utf8_unchecked(data)
         }
     }
 
     pub(crate) fn as_mut_str(&mut self) -> &mut str {
         unsafe {
-            let data = from_raw_parts_mut(self.data.as_mut().as_mut_ptr(), self.len());
+            let data = from_raw_parts_mut(self.data.as_mut().as_mut_ptr().cast(), self.len());
             from_utf8_unchecked_mut(data)
         }
     }
 
-    pub(crate) fn insert_bytes(&mut self, index: usize, bytes: &[u8]) {
-        assert!(self.as_str().is_char_boundary(index));
+    //Very unsafe: Caller needs to ensure that the string stays properly encoded
+    //and that the string doesn't overflow
+    pub(crate) unsafe fn insert_bytes(&mut self, index: usize, bytes: &[u8]) {
+        debug_assert!(self.as_str().is_char_boundary(index));
+        debug_assert!(bytes.len() + self.len() <= Mode::MAX_INLINE);
+        debug_assert!(std::str::from_utf8(bytes).is_ok());
+
         if bytes.is_empty() {
             return;
         }
         let len = self.len();
-        unsafe {
-            let ptr = self.data.as_mut().as_mut_ptr();
-            if index != len {
-                ptr.add(index + bytes.len())
-                    .copy_from(&self.data.as_ref()[index], len - index);
-            }
-            ptr.add(index)
-                .copy_from_nonoverlapping(bytes.as_ptr(), bytes.len());
+        let ptr = self.data.as_mut_ptr();
+        if index != len {
+            ptr.add(index + bytes.len())
+                .copy_from(self.data.as_ptr().add(index), len - index);
         }
-        self.set_size(len + bytes.len());
+        ptr.add(index)
+            .copy_from_nonoverlapping(bytes.as_ptr().cast(), bytes.len());
+        self.set_len(len + bytes.len());
     }
 
-    pub(crate) fn remove_bytes(&mut self, start: usize, end: usize) {
+    //Caller needs to ensure that the string stays properly encoded
+    pub(crate) unsafe fn remove_bytes(&mut self, start: usize, end: usize) {
         let len = self.len();
-        assert!(start <= end);
-        assert!(end <= len);
-        assert!(self.as_str().is_char_boundary(start));
-        assert!(self.as_str().is_char_boundary(end));
+        debug_assert!(start <= end);
+        debug_assert!(end <= len);
+        debug_assert!(self.as_str().is_char_boundary(start));
+        debug_assert!(self.as_str().is_char_boundary(end));
         if start == end {
             return;
         }
         if end < len {
-            unsafe {
-                let ptr = self.data.as_mut().as_mut_ptr();
-                ptr.add(start).copy_from(ptr.add(end), len - end);
-            }
+            let ptr = self.data.as_mut_ptr();
+            ptr.add(start).copy_from(ptr.add(end), len - end);
         }
-        self.set_size(len - (end - start));
+        self.set_len(len - (end - start));
     }
 }
 
 impl<Mode: SmartStringMode> From<&'_ [u8]> for InlineString<Mode> {
     fn from(bytes: &[u8]) -> Self {
         let len = bytes.len();
-        debug_assert!(len <= Mode::MAX_INLINE);
+        assert!(len <= Mode::MAX_INLINE);
+        assert!(std::str::from_utf8(bytes).is_ok());
         let mut out = Self::new();
-        out.marker = Marker::new_inline(len as u8);
-        out.data.as_mut()[..len].copy_from_slice(bytes);
+        for i in 0..len {
+            out.data[i] = MaybeUninit::new(bytes[i]);
+        }
+        unsafe {
+            out.set_len(len);
+        }
         out
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,124 +1,48 @@
-use crate::{bounds_for, boxed::BoxedString, inline::InlineString, SmartString, SmartStringMode};
+use crate::{SmartString, SmartStringMode, casts::StringCastMut};
 use std::{
     fmt::{Debug, Error, Formatter},
     iter::FusedIterator,
-    ops::RangeBounds,
-    str::Chars,
-    string::Drain as StringDrain,
+    ops::{RangeBounds, Bound},
 };
 
 /// A draining iterator for a [`SmartString`][SmartString].
 ///
 /// [SmartString]: struct.SmartString.html
-pub struct Drain<'a, Mode>(DrainCast<'a, Mode>)
-where
-    Mode: SmartStringMode;
-
-enum DrainCast<'a, Mode>
-where
-    Mode: SmartStringMode,
-{
-    Boxed {
-        string: *mut SmartString<Mode>,
-        iter: Option<StringDrain<'a>>,
-    },
-    Inline {
-        string: *mut InlineString<Mode>,
-        start: usize,
-        end: usize,
-        iter: Chars<'a>,
-    },
+pub struct Drain<'a, Mode: SmartStringMode> {
+    string: *mut SmartString<Mode>,
+    iterator: std::str::Chars<'a>,
+    start: usize,
+    end: usize,
 }
 
-impl<'a, Mode> Drain<'a, Mode>
-where
-    Mode: SmartStringMode,
-{
-    pub(crate) fn new<R>(string: &'a mut SmartString<Mode>, range: R) -> Self
-    where
-        R: RangeBounds<usize>,
-    {
-        let string_ptr: *mut _ = string;
-        Drain(match string.cast_mut() {
-            crate::casts::StringCastMut::Boxed(boxed) => DrainCast::Boxed {
-                string: string_ptr,
-                iter: Some(boxed.string_mut().drain(range)),
-            },
-            crate::casts::StringCastMut::Inline(inline) => {
-                let len = inline.len();
-                let (start, end) = bounds_for(&range, len);
-                let string_ptr: *mut _ = inline;
-                let iter = inline.as_str()[start..end].chars();
-                DrainCast::Inline {
-                    string: string_ptr,
-                    start,
-                    end,
-                    iter,
-                }
-            }
-        })
-    }
-}
-
-impl<'a, Mode> Drop for Drain<'a, Mode>
-where
-    Mode: SmartStringMode,
-{
-    fn drop(&mut self) {
-        match self.0 {
-            DrainCast::Boxed {
-                string,
-                ref mut iter,
-            } => unsafe {
-                iter.take();
-                (*string).try_demote();
-            },
-            DrainCast::Inline {
-                string, start, end, ..
-            } => {
-                unsafe { (*string).remove_bytes(start, end) };
-            }
+impl<'a, Mode: SmartStringMode> Drain<'a, Mode> {
+    /// Creates a new draining iterator for a [`SmartString`][SmartString].
+    ///
+    /// [SmartString]: struct.SmartString.html
+    pub fn new<R: RangeBounds<usize>>(from: &'a mut SmartString<Mode>, range: R) -> Self {
+        let start = match range.start_bound() {
+            Bound::Included(x) => *x,
+            Bound::Unbounded => 0,
+            Bound::Excluded(x) => x.checked_add(1).unwrap(),
+        };
+        let end = match range.end_bound() {
+            Bound::Excluded(x) => *x,
+            Bound::Unbounded => from.len(),
+            Bound::Included(x) => x.checked_add(1).unwrap(),
+        };
+        Self {
+            string: from,
+            iterator: from.as_str()[start..end].chars(),
+            start,
+            end,
         }
     }
 }
 
-impl<'a, Mode> Iterator for Drain<'a, Mode>
-where
-    Mode: SmartStringMode,
-{
+impl<'a, Mode: SmartStringMode> Iterator for Drain<'a, Mode> {
     type Item = char;
-
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            DrainCast::Boxed {
-                iter: Some(iter), ..
-            } => iter.next(),
-            DrainCast::Boxed { iter: None, .. } => unreachable!(),
-            DrainCast::Inline { iter, .. } => iter.next(),
-        }
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match &self.0 {
-            DrainCast::Boxed {
-                iter: Some(iter), ..
-            } => iter.size_hint(),
-            DrainCast::Boxed { iter: None, .. } => unreachable!(),
-            DrainCast::Inline { iter, .. } => iter.size_hint(),
-        }
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            DrainCast::Boxed {
-                iter: Some(iter), ..
-            } => iter.next_back(),
-            DrainCast::Boxed { iter: None, .. } => unreachable!(),
-            DrainCast::Inline { iter, .. } => iter.next_back(),
-        }
+        self.iterator.next()
     }
 }
 
@@ -128,13 +52,7 @@ where
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        match &mut self.0 {
-            DrainCast::Boxed {
-                iter: Some(iter), ..
-            } => iter.next_back(),
-            DrainCast::Boxed { iter: None, .. } => unreachable!(),
-            DrainCast::Inline { iter, .. } => iter.next_back(),
-        }
+        self.iterator.next_back()
     }
 }
 
@@ -146,5 +64,20 @@ where
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         f.pad("Drain { ... }")
+    }
+}
+
+impl<'a, Mode> Drop for Drain<'a, Mode>
+where
+    Mode: SmartStringMode,
+{
+    fn drop(&mut self) {
+        //We must first replace the iterator with a dummy one, so it won't dangle
+        self.iterator = "".chars();
+        //Now we can safely clear the string
+        unsafe { match (*self.string).cast_mut() {
+            StringCastMut::Boxed(mut string) => {string.drain(self.start..self.end);},
+            StringCastMut::Inline(string) => string.remove_bytes(self.start, self.end),
+        }}
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,8 +1,8 @@
-use crate::{SmartString, SmartStringMode, casts::StringCastMut};
+use crate::{casts::StringCastMut, SmartString, SmartStringMode};
 use std::{
     fmt::{Debug, Error, Formatter},
     iter::FusedIterator,
-    ops::{RangeBounds, Bound},
+    ops::{Bound, RangeBounds},
 };
 
 /// A draining iterator for a [`SmartString`][SmartString].
@@ -75,9 +75,13 @@ where
         //We must first replace the iterator with a dummy one, so it won't dangle
         self.iterator = "".chars();
         //Now we can safely clear the string
-        unsafe { match (*self.string).cast_mut() {
-            StringCastMut::Boxed(mut string) => {string.drain(self.start..self.end);},
-            StringCastMut::Inline(string) => string.remove_bytes(self.start, self.end),
-        }}
+        unsafe {
+            match (*self.string).cast_mut() {
+                StringCastMut::Boxed(mut string) => {
+                    string.drain(self.start..self.end);
+                }
+                StringCastMut::Inline(string) => string.remove_bytes(self.start, self.end),
+            }
+        }
     }
 }

--- a/src/marker_byte.rs
+++ b/src/marker_byte.rs
@@ -2,77 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// We need to know the endianness of the platform to know how to deal with pointers.
-#[cfg(target_endian = "big")]
-const UPSIDE_DOWN_LAND: bool = false;
-#[cfg(target_endian = "little")]
-const UPSIDE_DOWN_LAND: bool = true;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Discriminant {
     Boxed,
     Inline,
-}
-
-impl Discriminant {
-    #[inline(always)]
-    fn from_bit(bit: bool) -> Self {
-        if bit {
-            Self::Inline
-        } else {
-            Self::Boxed
-        }
-    }
-
-    #[inline(always)]
-    fn bit(self) -> u8 {
-        match self {
-            Self::Boxed => 0,
-            Self::Inline => 1,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct Marker(u8);
-
-impl Marker {
-    #[inline(always)]
-    fn assemble(discriminant: Discriminant, data: u8) -> u8 {
-        let data = data;
-        if UPSIDE_DOWN_LAND {
-            data << 1 | discriminant.bit()
-        } else {
-            discriminant.bit() << 7 | data
-        }
-    }
-
-    pub(crate) fn new_inline(data: u8) -> Self {
-        debug_assert!(data < 0x80);
-        Self(Self::assemble(Discriminant::Inline, data))
-    }
-
-    #[inline(always)]
-    pub(crate) fn discriminant(self) -> Discriminant {
-        Discriminant::from_bit(if UPSIDE_DOWN_LAND {
-            self.0 & 0x01 != 0
-        } else {
-            self.0 & 0x80 != 0
-        })
-    }
-
-    #[inline(always)]
-    pub(crate) fn data(self) -> u8 {
-        if UPSIDE_DOWN_LAND {
-            self.0 >> 1
-        } else {
-            self.0 & 0x7f
-        }
-    }
-
-    #[inline(always)]
-    pub(crate) fn set_data(&mut self, byte: u8) {
-        debug_assert!(byte < 0x80);
-        self.0 = Self::assemble(self.discriminant(), byte);
-    }
 }

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -1,6 +1,7 @@
 //! `proptest` strategies (requires the `proptest` feature flag).
 
 use crate::{SmartString, SmartStringMode};
+use proptest::proptest;
 use proptest::strategy::{BoxedStrategy, Strategy};
 use proptest::string::Error;
 
@@ -14,4 +15,11 @@ where
     Mode: 'static,
 {
     proptest::string::string_regex(regex).map(|g| g.prop_map(SmartString::from).boxed())
+}
+
+proptest! {
+    #[test]
+    fn strategy(string in string_regex(".+").unwrap()) {
+        assert!(!SmartString::<crate::LazyCompact>::is_empty(&string));
+    }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -363,6 +363,11 @@ fn assert_invariants<Mode: SmartStringMode>(control: &str, subject: &SmartString
     );
     let control_smart: SmartString<Mode> = control.into();
     assert_eq!(Ordering::Equal, subject.cmp(&control_smart));
+    if std::mem::size_of::<SmartString<Mode>>() == std::mem::size_of::<Option<SmartString<Mode>>>() {
+        let ptr : *const Option<SmartString<Mode>> = (subject as *const SmartString<Mode>).cast();
+        //Todo: should include a black box to prevent rustc from optimizing this
+        assert!(unsafe {(*ptr).is_some()});
+    }
 }
 
 pub fn test_everything<Mode: SmartStringMode>(constructor: Constructor, actions: Vec<Action>) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -363,10 +363,11 @@ fn assert_invariants<Mode: SmartStringMode>(control: &str, subject: &SmartString
     );
     let control_smart: SmartString<Mode> = control.into();
     assert_eq!(Ordering::Equal, subject.cmp(&control_smart));
-    if std::mem::size_of::<SmartString<Mode>>() == std::mem::size_of::<Option<SmartString<Mode>>>() {
-        let ptr : *const Option<SmartString<Mode>> = (subject as *const SmartString<Mode>).cast();
+    if std::mem::size_of::<SmartString<Mode>>() == std::mem::size_of::<Option<SmartString<Mode>>>()
+    {
+        let ptr: *const Option<SmartString<Mode>> = (subject as *const SmartString<Mode>).cast();
         //Todo: should include a black box to prevent rustc from optimizing this
-        assert!(unsafe {(*ptr).is_some()});
+        assert!(unsafe { (*ptr).is_some() });
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -511,4 +511,12 @@ mod tests {
             SmartString::<Compact>::from("\u{323}\u{323}\u{323}ω\u{323}\u{323}\u{323}㌣\u{e323}㤘");
         s.remove(20);
     }
+
+    #[test]
+    fn return_reasonable_capacity() {
+        let boxed = SmartString::<LazyCompact>::from("𝕃𝕠𝕟𝕘𝕖𝕣 𝕥𝕙𝕒𝕟 𝟚𝟛 𝕓𝕪𝕥𝕖𝕤");
+        let inlined = SmartString::<LazyCompact>::from("Shorter");
+        assert!(boxed.capacity() <= isize::MAX as usize);
+        assert!(inlined.capacity() == std::mem::size_of::<String>() - 1);
+    }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -504,4 +504,11 @@ mod tests {
         assert_eq!(control_smart, string);
         assert_eq!(Ordering::Equal, string.cmp(&control_smart));
     }
+
+    #[test]
+    fn dont_panic_on_removing_last_index_from_an_inline_string() {
+        let mut s =
+            SmartString::<Compact>::from("\u{323}\u{323}\u{323}ω\u{323}\u{323}\u{323}㌣\u{e323}㤘");
+        s.remove(20);
+    }
 }


### PR DESCRIPTION
### New implementation works as follows:
* Store the discriminant bit in the most significant bit of `SmartString`
* Arrange the fields of ´BoxedString´ so that the discriminant bit is the most significant bit of capacity or size
  * If on a little endian arch and lazy_null_pointer_optimizations is disabled, use size, otherwise capacity
* Since transmuting into a `String` is not guranteed to work, boxed string methods use a new struct called `StringReference`, which contains a reference to a `SmartString`, and a `String`. At the end of it's lifetime the contents of the `String` are transferred to the `SmartString`. This replaces `try_demote`

#### Null pointer optimizations:
* If the string is inlined, the discriminant bit is set, so the `usize` it is a part of (in the boxed version) is not zero
* If the string is boxed, the capacity is not zero
* If the string is boxed, and the mode is `Compact`, the size is also not zero

### Things to do:
* Fix bug #7
* More tests?
* Decide if lazy_null_pointer_optimizations should be a flag or not (maybe not tbh)