### PR TITLE
no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ name = "smartstring"
 harness = false
 
 [features]
+default = ["std"]
+std = []
 test = ["arbitrary", "arbitrary/derive"]
 
 [dependencies]

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::cmp::Ordering;
+use crate::lib::*;
 
 pub trait BoxedString {
     fn string(&self) -> &String;

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@
 use crate::{boxed::BoxedString, inline::InlineString, SmartString};
 use static_assertions::{assert_eq_size, const_assert, const_assert_eq};
 use std::mem::{align_of, size_of};
+use crate::lib::*;
 
 /// A compact string representation equal to [`String`][String] in size with guaranteed inlining.
 ///

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,8 +4,12 @@ use std::{
     iter::FusedIterator,
     ops::RangeBounds,
     str::Chars,
-    string::Drain as StringDrain,
 };
+#[cfg(not(feature = "std"))]
+use alloc::string::Drain as StringDrain;
+#[cfg(feature = "std")]
+use std::string::Drain as StringDrain;
+
 
 /// A draining iterator for a [`SmartString`][SmartString].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,38 @@
 //! [Deserialize]: https://docs.rs/serde/latest/serde/trait.Deserialize.html
 //! [Arbitrary]: https://docs.rs/arbitrary/latest/arbitrary/trait.Arbitrary.html
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #![forbid(rust_2018_idioms)]
 #![deny(nonstandard_style)]
 #![warn(unreachable_pub, missing_debug_implementations, missing_docs)]
+
+#[cfg(not(feature = "std"))]
+extern crate core as std;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[doc(hidden)]
+pub mod lib {
+    #[cfg(not(feature = "std"))]
+    pub use alloc::string::{String, ToString};
+    #[cfg(feature = "std")]
+    pub use std::string::{String, ToString};
+
+    #[cfg(not(feature = "std"))]
+    pub use alloc::vec::Vec;
+    #[cfg(not(feature = "std"))]
+    pub use alloc::{format, vec};
+    #[cfg(feature = "std")]
+    pub use std::vec::Vec;
+
+    #[cfg(not(feature = "std"))]
+    pub use alloc::boxed::Box;
+    #[cfg(feature = "std")]
+    pub use std::boxed::Box;
+}
+use lib::*;
 
 use std::{
     borrow::{Borrow, BorrowMut},


### PR DESCRIPTION
I have succesfully implemented `no_std` 
To use run with `cargo build --no-default-features`

It passed no std check
https://github.com/mystor/cargo-no-std-check