### PR TITLE
Implemented `PartialEq<&str>` for `SmartString<Mode>`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1074,6 +1074,12 @@ impl<Mode: SmartStringMode> PartialEq<str> for SmartString<Mode> {
     }
 }
 
+impl<Mode: SmartStringMode> PartialEq<&'_ str> for SmartString<Mode> {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
 impl<Mode: SmartStringMode> PartialEq<SmartString<Mode>> for &'_ str {
     fn eq(&self, other: &SmartString<Mode>) -> bool {
         other.eq(*self)

--- a/src/test.rs
+++ b/src/test.rs
@@ -406,6 +406,23 @@ mod tests {
         fn proptest_ordering_lazycompact(left: String, right: String) {
             test_ordering::<LazyCompact>(left,right)
         }
+
+        #[test]
+        fn proptest_eq(left: String, right: String) {
+            fn test_eq<Mode: SmartStringMode>(left: &str, right: &str) {
+                let smart_left = SmartString::<Mode>::from(left);
+                let smart_right = SmartString::<Mode>::from(right);
+                assert_eq!(smart_left, left);
+                assert_eq!(smart_left, *left);
+                assert_eq!(smart_left, left.to_string());
+                assert_eq!(smart_left == smart_right, left == right);
+                assert_eq!(left, smart_left);
+                assert_eq!(*left, smart_left);
+                assert_eq!(left.to_string(), smart_left);
+            }
+            test_eq::<Compact>(&left, &right);
+            test_eq::<LazyCompact>(&left, &right);
+        }
     }
 
     #[test]


### PR DESCRIPTION
This is useful for comparing slices of strings. Also, added some tests for various PartialEq flavors.

Fixes #15 