### PR TITLE
Fix #![no_std] builds.

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,4 +1,8 @@
 use crate::{SmartString, SmartStringMode};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 impl<Mode: SmartStringMode> Arbitrary for SmartString<Mode>

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use alloc::string::String;
 use core::cmp::Ordering;
 
 pub trait BoxedString {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::{boxed::BoxedString, inline::InlineString, SmartString};
+use alloc::string::String;
 use core::mem::{align_of, size_of};
 use static_assertions::{assert_cfg, assert_eq_size, const_assert, const_assert_eq};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,10 @@
 
 extern crate alloc;
 
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 use core::{
     borrow::{Borrow, BorrowMut},
     cmp::Ordering,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,5 @@
 use crate::{SmartString, SmartStringMode};
+use alloc::string::String;
 use core::{fmt, marker::PhantomData};
 
 use serde::{


### PR DESCRIPTION
Closes #17.

This adds `use` statements to import `alloc` types such as `String`, `Box`, and `ToString` manually to resolve `#![no_std]` build issues.

I also have a [separate commit](https://github.com/okready/smartstring/tree/add-no_std-github-actions-tests) with an update to the GitHub Actions CI configuration to add `cargo check` and Clippy tests with `std` disabled. If it's acceptable, I can combine it with this PR or create a separate PR with it once this is merged.