### PR TITLE
Use no-std-compat crate to support no-std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [features]
 default = ["std"]
-std = []
+std = ["no-std-compat/std"]
 test = ["std", "arbitrary", "arbitrary/derive"]
 
 [dependencies]
@@ -32,6 +32,7 @@ static_assertions = "1.1.0"
 serde = { version = "1", optional = true }
 arbitrary = { version = "0.4", optional = true }
 proptest = { version = "0.10", optional = true }
+no-std-compat = { vresion = "0.4", features = ["alloc"] }
 
 [dev-dependencies]
 proptest = "0.10"

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,5 +1,6 @@
 use crate::{SmartString, SmartStringMode};
 use arbitrary::{Arbitrary, Result, Unstructured};
+use std::prelude::v1::*;
 
 impl<Mode: SmartStringMode> Arbitrary for SmartString<Mode>
 where

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use core::cmp::Ordering;
+use std::prelude::v1::*;
 
 pub trait BoxedString {
     fn string(&self) -> &String;

--- a/src/casts.rs
+++ b/src/casts.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::{inline::InlineString, SmartStringMode};
+use std::prelude::v1::*;
 
 pub(crate) enum StringCast<'a, Mode: SmartStringMode> {
     Boxed(&'a Mode::BoxedString),

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@
 use crate::{boxed::BoxedString, inline::InlineString, SmartString};
 use core::mem::{align_of, size_of};
 use static_assertions::{assert_cfg, assert_eq_size, const_assert, const_assert_eq};
+use std::prelude::v1::*;
 
 /// A compact string representation equal to [`String`][String] in size with guaranteed inlining.
 ///

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -8,6 +8,7 @@ use core::{
     slice::{from_raw_parts, from_raw_parts_mut},
     str::{from_utf8_unchecked, from_utf8_unchecked_mut},
 };
+use std::prelude::v1::*;
 
 #[repr(C)]
 pub(crate) struct InlineString<Mode: SmartStringMode> {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -6,6 +6,7 @@ use core::{
     ops::RangeBounds,
     str::Chars,
 };
+use std::prelude::v1::*;
 
 /// A draining iterator for a [`SmartString`][SmartString].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@
 
 extern crate alloc;
 
+extern crate no_std_compat as std;
+
 use core::{
     borrow::{Borrow, BorrowMut},
     cmp::Ordering,
@@ -154,6 +156,7 @@ use core::{
     ptr::drop_in_place,
     str::FromStr,
 };
+use std::prelude::v1::*;
 
 #[cfg(feature = "std")]
 use std::borrow::Cow;

--- a/src/marker_byte.rs
+++ b/src/marker_byte.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::prelude::v1::*;
+
 // We need to know the endianness of the platform to know how to deal with pointers.
 #[cfg(target_endian = "big")]
 const UPSIDE_DOWN_LAND: bool = false;

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -4,6 +4,7 @@ use crate::{SmartString, SmartStringMode};
 use proptest::proptest;
 use proptest::strategy::{BoxedStrategy, Strategy};
 use proptest::string::Error;
+use std::prelude::v1::*;
 
 /// Creates a strategy which generates [`SmartString`][SmartString]s matching the given regular expression.
 ///

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,5 +1,6 @@
 use crate::{SmartString, SmartStringMode};
 use core::{fmt, marker::PhantomData};
+use std::prelude::v1::*;
 
 use serde::{
     de::{Error, Visitor},

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![cfg(feature = "std")]
+
 use crate::{SmartString, SmartStringMode};
 use std::{
     cmp::Ordering,


### PR DESCRIPTION
This PR differs from the solution proposed by https://github.com/okready/smartstring in that it uses the [`no-std-compat`](https://crates.io/crates/no_std_compat) crate to map types etc. in order to provide support for `no-std`.

For those who needs this right away for `no-std`, can pull from https://github.com/rhaiscript/smartstring