### PR TITLE
Update arbitrary to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ test = ["std", "arbitrary", "arbitrary/derive"]
 [dependencies]
 static_assertions = "1.1.0"
 serde = { version = "1", optional = true }
-arbitrary = { version = "0.4", optional = true }
+arbitrary = { version = "1.1.0", optional = true }
 proptest = { version = "0.10", optional = true }
 
 [dev-dependencies]

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -20,8 +20,4 @@ where
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
         String::size_hint(depth)
     }
-
-    // fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-    //     Box::new(self.to_string().shrink().map(Self::from))
-    // }
 }

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -5,7 +5,7 @@ use alloc::{
 };
 use arbitrary::{Arbitrary, Result, Unstructured};
 
-impl<Mode: SmartStringMode> Arbitrary for SmartString<Mode>
+impl<'a, Mode: SmartStringMode> Arbitrary<'a> for SmartString<Mode>
 where
     Mode: 'static,
 {
@@ -21,7 +21,7 @@ where
         String::size_hint(depth)
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        Box::new(self.to_string().shrink().map(Self::from))
-    }
+    // fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+    //     Box::new(self.to_string().shrink().map(Self::from))
+    // }
 }


### PR DESCRIPTION
The arbitrary version currently used (0.4.0) is a few years old and doesn't have trait compatibility with modern arbitrary. 1.1.0 is currently the most recent version. 