### PR TITLE
add `From<char>` to SmartString

### DIFF
--- a/src/inline.rs
+++ b/src/inline.rs
@@ -80,6 +80,17 @@ impl InlineString {
     }
 }
 
+impl From<char> for InlineString {
+    fn from(c: char) -> Self {
+        let len = c.len_utf8();
+        let mut out = Self::new();
+
+        out.marker = Marker::new_inline(len as u8);
+        c.encode_utf8(&mut out.data);
+        out
+    }
+}
+
 impl From<&str> for InlineString {
     fn from(string: &str) -> Self {
         let len = string.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,6 +643,12 @@ impl<Mode: SmartStringMode> IndexMut<RangeToInclusive<usize>> for SmartString<Mo
     }
 }
 
+impl<Mode: SmartStringMode> From<char> for SmartString<Mode> {
+    fn from(c: char) -> Self {
+        Self::from_inline(c.into())
+    }
+}
+
 impl<Mode: SmartStringMode> From<&'_ str> for SmartString<Mode> {
     fn from(string: &'_ str) -> Self {
         if string.len() > MAX_INLINE {

--- a/src/test.rs
+++ b/src/test.rs
@@ -563,4 +563,15 @@ mod tests {
         assert_eq!(std_s, unsmart_s);
         // This test exists just to provoke a Miri problem when dropping a string created by SmartString::into::<String>() (#28)
     }
+
+    #[test]
+    fn from_char() {
+        let c = 'a';
+        let std_s = String::from(c);
+        let smart_s = SmartString::<LazyCompact>::from(c);
+        let unsmart_s = smart_s.clone().to_string();
+        assert_eq!(smart_s, std_s);
+        assert_eq!(smart_s, unsmart_s);
+        assert_eq!(std_s, unsmart_s);
+    }
 }


### PR DESCRIPTION
This commit creates an implementation for `SmartString` itself and consequently for `InlineString`. Was working with this crate earlier and to my surprise found out these were missing, so I added them. Thanks for the great crate by the way! :)