### PR TITLE
perf: add #[inline] to check_alignment()

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -32,6 +32,7 @@ pub(crate) struct BoxedString {
 ///
 /// Returns `true` if aligned to an odd address, `false` if even. The sense of
 /// the boolean is "does this look like an InlineString? true/false"
+#[inline]
 fn check_alignment(ptr: *const u8) -> bool {
     ptr.align_offset(2) > 0
 }
@@ -53,6 +54,7 @@ impl GenericString for BoxedString {
 impl BoxedString {
     const MINIMAL_CAPACITY: usize = MAX_INLINE * 2;
 
+    #[inline]
     pub(crate) fn check_alignment(this: &Self) -> bool {
         check_alignment(this.ptr.as_ptr())
     }


### PR DESCRIPTION
Hi!

We noticed a significant slowdown in our production service after upgrading from 0.2.x to 1.x. After profiling, we determined that the culprit was the `check_alignment()` function, which wasn’t inlined, despite being very small, and was taking up a lot of time. Marking this function as `#[inline]` fixed the problem.

Unfortunately, I didn’t find a way to replicate this regression in a benchmark, but inlining such a small function is unlikely to cause performance problems and was significantly beneficial in our case.