### PR TITLE
Add `extend_one`, `extend_reserve` and `ensure_capacity`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ harness = false
 [features]
 default = ["std"]
 std = []
+unstable = []
 test = ["std", "arbitrary", "arbitrary/derive"]
 
 [dependencies]

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -32,6 +32,7 @@ pub(crate) struct BoxedString {
 ///
 /// Returns `true` if aligned to an odd address, `false` if even. The sense of
 /// the boolean is "does this look like an InlineString? true/false"
+#[inline]
 fn check_alignment(ptr: *const u8) -> bool {
     ptr.align_offset(2) > 0
 }
@@ -53,6 +54,7 @@ impl GenericString for BoxedString {
 impl BoxedString {
     const MINIMAL_CAPACITY: usize = MAX_INLINE * 2;
 
+    #[inline]
     pub(crate) fn check_alignment(this: &Self) -> bool {
         check_alignment(this.ptr.as_ptr())
     }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -38,6 +38,10 @@ fn check_alignment(ptr: *const u8) -> bool {
 }
 
 impl GenericString for BoxedString {
+    fn cap(&self) -> usize {
+        self.cap
+    }
+
     fn set_size(&mut self, size: usize) {
         self.len = size;
         debug_assert!(self.len <= self.cap);

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -56,6 +56,10 @@ impl DerefMut for InlineString {
 }
 
 impl GenericString for InlineString {
+    fn cap(&self) -> usize {
+        MAX_INLINE
+    }
+
     fn set_size(&mut self, size: usize) {
         self.marker.set_data(size as u8);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,17 @@ impl<Mode: SmartStringMode> SmartString<Mode> {
         }
     }
 
+    /// Ensures that the string has a capacity of at least the given number of bytes.
+    /// This function will reallocate the string (and therefore unbox a boxed string)
+    /// in order to fit the new capacity.
+    ///
+    /// Note that if the string's capacity is already large enough, this function does nothing.
+    /// This also applies to inline strings, when `capacity` is less than or equal to
+    /// [`MAX_INLINE`].
+    pub fn ensure_capacity(&mut self, target_cap: usize) {
+        string_op_grow!(ops::EnsureCapacity, self, target_cap)
+    }
+
     /// Push a character to the end of the string.
     pub fn push(&mut self, ch: char) {
         string_op_grow!(ops::Push, self, ch)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@
 //! | Feature | Description |
 //! | ------- | ----------- |
 //! | [`arbitrary`](https://crates.io/crates/arbitrary) | [`Arbitrary`][Arbitrary] implementation for [`SmartString`]. |
+//! | `unstable` | Features only available with a nightly Rust compiler. Currently this is only the [`extend_reserve`][core::iter::traits::collect::Extend::extend_reserve] implementation for [`SmartString`]. |
 //! | [`proptest`](https://crates.io/crates/proptest) | A strategy for generating [`SmartString`]s from a regular expression. |
 //! | [`serde`](https://crates.io/crates/serde) | [`Serialize`][Serialize] and [`Deserialize`][Deserialize] implementations for [`SmartString`]. |
 //!
@@ -102,6 +103,7 @@
 #![warn(unreachable_pub, missing_debug_implementations, missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(needs_allocator_feature, feature(allocator_api))]
+#![cfg_attr(feature = "unstable", feature(extend_one))]
 
 extern crate alloc;
 
@@ -721,6 +723,11 @@ impl<'a, Mode: SmartStringMode> Extend<&'a str> for SmartString<Mode> {
             self.push_str(item);
         }
     }
+
+    #[cfg(feature = "unstable")]
+    fn extend_one(&mut self, item: &'a str) {
+        self.push_str(item)
+    }
 }
 
 impl<'a, Mode: SmartStringMode> Extend<&'a char> for SmartString<Mode> {
@@ -729,6 +736,16 @@ impl<'a, Mode: SmartStringMode> Extend<&'a char> for SmartString<Mode> {
             self.push(*item);
         }
     }
+
+    #[cfg(feature = "unstable")]
+    fn extend_one(&mut self, item: &'a char) {
+        self.push(*item)
+    }
+
+    #[cfg(feature = "unstable")]
+    fn extend_reserve(&mut self, additional: usize) {
+        self.ensure_capacity(self.capacity() + additional)
+    }
 }
 
 impl<Mode: SmartStringMode> Extend<char> for SmartString<Mode> {
@@ -736,6 +753,16 @@ impl<Mode: SmartStringMode> Extend<char> for SmartString<Mode> {
         for item in iter {
             self.push(item);
         }
+    }
+
+    #[cfg(feature = "unstable")]
+    fn extend_one(&mut self, item: char) {
+        self.push(item)
+    }
+
+    #[cfg(feature = "unstable")]
+    fn extend_reserve(&mut self, additional: usize) {
+        self.ensure_capacity(self.capacity() + additional)
     }
 }
 
@@ -753,6 +780,11 @@ impl<Mode: SmartStringMode> Extend<String> for SmartString<Mode> {
             self.push_str(&item);
         }
     }
+
+    #[cfg(feature = "unstable")]
+    fn extend_one(&mut self, item: String) {
+        self.push_str(&item)
+    }
 }
 
 impl<'a, Mode: SmartStringMode + 'a> Extend<&'a SmartString<Mode>> for SmartString<Mode> {
@@ -761,6 +793,11 @@ impl<'a, Mode: SmartStringMode + 'a> Extend<&'a SmartString<Mode>> for SmartStri
             self.push_str(item);
         }
     }
+
+    #[cfg(feature = "unstable")]
+    fn extend_one(&mut self, item: &'a SmartString<Mode>) {
+        self.push_str(item)
+    }
 }
 
 impl<'a, Mode: SmartStringMode> Extend<&'a String> for SmartString<Mode> {
@@ -768,6 +805,11 @@ impl<'a, Mode: SmartStringMode> Extend<&'a String> for SmartString<Mode> {
         for item in iter {
             self.push_str(item);
         }
+    }
+
+    #[cfg(feature = "unstable")]
+    fn extend_one(&mut self, item: &'a String) {
+        self.push_str(item)
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -18,6 +18,7 @@ use core::{
 };
 
 pub(crate) trait GenericString: Deref<Target = str> + DerefMut<Target = str> {
+    fn cap(&self) -> usize;
     fn set_size(&mut self, size: usize);
     fn as_mut_capacity_slice(&mut self) -> &mut [u8];
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -136,6 +136,15 @@ impl Truncate {
     }
 }
 
+pub(crate) struct EnsureCapacity;
+impl EnsureCapacity {
+    pub(crate) fn cap<S: GenericString>(this: &S, target_cap: usize) -> usize {
+        this.cap().max(target_cap)
+    }
+
+    pub(crate) fn op<S: GenericString>(_this: &mut S, _target_cap: usize) {}
+}
+
 pub(crate) struct Pop;
 impl Pop {
     pub(crate) fn op<S: GenericString>(this: &mut S) -> Option<char> {


### PR DESCRIPTION
The first two functions are an implementation of unstable functions on `Extend`. The third one is both a backend for the other two, as well as a standalone public API.

Fixes #42, depends on #41 .