### PR TITLE
Size optimization for `Option`

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -179,7 +179,7 @@ impl From<String> for BoxedString {
                     Self {
                         cap,
                         len,
-                        ptr: aligned_ptr.cast(),
+                        ptr: TaggedPtr::new(aligned_ptr.as_ptr() as *mut _).unwrap(),
                     }
                 } else {
                     Self::from_str(cap, &s)
@@ -204,7 +204,7 @@ impl From<BoxedString> for String {
             use alloc::alloc::Allocator;
             let allocator = alloc::alloc::Global;
             if let Ok(aligned_ptr) =
-                unsafe { allocator.grow(ptr, BoxedString::layout_for(cap), new_layout) }
+                unsafe { allocator.grow(ptr.as_non_null(), BoxedString::layout_for(cap), new_layout) }
             {
                 core::mem::forget(s);
                 unsafe { String::from_raw_parts(aligned_ptr.as_ptr().cast(), len, cap) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,9 @@ pub use config::{Compact, LazyCompact, SmartStringMode, MAX_INLINE};
 mod marker_byte;
 use marker_byte::Discriminant;
 
+mod tagged_ptr;
+use tagged_ptr::TaggedPtr;
+
 mod inline;
 use inline::InlineString;
 
@@ -297,10 +300,7 @@ impl<Mode: SmartStringMode> SmartString<Mode> {
     }
 
     fn discriminant(&self) -> Discriminant {
-        let str_ptr: *const BoxedString =
-            &self.data as *const _ as *const BoxedString;
-        #[allow(unsafe_code)]
-        Discriminant::from_bit(BoxedString::check_alignment(unsafe { &*str_ptr }))
+        self.data.marker.discriminant()
     }
 
     fn cast(&self) -> StringCast<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,7 @@ use core::{
     str::FromStr,
 };
 
-#[cfg(feature = "std")]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 mod config;
 pub use config::{Compact, LazyCompact, SmartStringMode, MAX_INLINE};
@@ -692,7 +691,6 @@ impl<Mode: SmartStringMode> From<Box<str>> for SmartString<Mode> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<Mode: SmartStringMode> From<Cow<'_, str>> for SmartString<Mode> {
     fn from(string: Cow<'_, str>) -> Self {
         if string.len() > MAX_INLINE {

--- a/src/marker_byte.rs
+++ b/src/marker_byte.rs
@@ -29,6 +29,17 @@ impl Discriminant {
     }
 }
 
+/// We now use this type to facilitate Option size optimization.
+/// The low two bits are used to determine both the discriminant and the None state.
+///
+/// 00000000 - None
+/// xxxxxx01 - unused
+/// xxxxxx10 - BoxedString
+/// xxxxxx11 - InlineString
+///
+/// BoxedString now uses TaggedPtr to ensure the low two bits form the 10 pattern.
+/// This guarantees the in-memory NonZeroU8 value is always in a valid state and that it matches the
+/// tagging convention of Marker.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Marker(NonZeroU8);
 

--- a/src/marker_byte.rs
+++ b/src/marker_byte.rs
@@ -38,7 +38,7 @@ impl Marker {
         debug_assert!(data < 0x40);
 
         #[allow(unsafe_code)]
-        unsafe { NonZeroU8::new_unchecked(0x80 | (data << 1) | discriminant.bit()) } // SAFETY: (0x80 | x) != 0 is guaranteed for all x
+        unsafe { NonZeroU8::new_unchecked((data << 2) | 2 | discriminant.bit()) } // SAFETY: (2 | x) != 0 is guaranteed for all x
     }
 
     #[inline(always)]
@@ -58,7 +58,7 @@ impl Marker {
 
     #[inline(always)]
     pub(crate) const fn data(self) -> u8 {
-        (self.0.get() & 0x7f) >> 1
+        self.0.get() >> 2
     }
 
     #[inline(always)]

--- a/src/tagged_ptr.rs
+++ b/src/tagged_ptr.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use core::ptr::NonNull;
+use core::num::NonZeroUsize;
+use core::marker::PhantomData;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GenericTaggedPtr<T, const MASK: usize, const PATTERN: usize>(NonZeroUsize, PhantomData<T>);
+impl<T, const MASK: usize, const PATTERN: usize> GenericTaggedPtr<T, MASK, PATTERN> {
+    pub(crate) fn new(v: *mut T) -> Option<Self> {
+        // this will be optimized away at compile time
+        if PATTERN == 0 || PATTERN & MASK != PATTERN {
+            panic!("fill must not be zero");
+        }
+
+        if v as usize == 0 || v as usize & MASK != 0 {
+            None
+        } else {
+            #[allow(unsafe_code)]
+            let ptr = unsafe { NonZeroUsize::new_unchecked((v as usize & !MASK) | PATTERN) }; // SAFETY: v | PATTERN != 0 because PATTERN != 0
+            Some(Self(ptr, PhantomData))
+        }
+    }
+    pub(crate) fn as_non_null(self) -> NonNull<T> {
+        #[allow(unsafe_code)]
+        unsafe { NonNull::new_unchecked((self.0.get() & !MASK) as *mut T) } // SAFETY: v & !MASK != 0 guaranteed from Self::new
+    }
+}
+
+pub(crate) type TaggedPtr = GenericTaggedPtr<u8, 3, 2>;
+
+#[test]
+fn check_filled_ptr() {
+    for i in 1..=1024 {
+        let v = i << 2;
+        let p = TaggedPtr::new(v as *mut _).unwrap();
+        assert_eq!(p.0.get(), v | 2);
+        assert_eq!(p.as_non_null().as_ptr() as usize, v);
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -527,19 +527,14 @@ mod tests {
     #[test]
     fn check_alignment() {
         use crate::boxed::BoxedString;
-        use crate::inline::InlineString;
         use crate::marker_byte::Discriminant;
 
-        let inline = InlineString::new();
-        let inline_ptr: *const InlineString = &inline;
-        let boxed_ptr: *const BoxedString = inline_ptr.cast();
-        #[allow(unsafe_code)]
-        let discriminant =
-            Discriminant::from_bit(BoxedString::check_alignment(unsafe { &*boxed_ptr }));
-        assert_eq!(Discriminant::Inline, discriminant);
+        let boxed = BoxedString::from_str(32, "welp");
+        let discriminant = SmartString::<LazyCompact>::from_boxed(boxed).discriminant();
+        assert_eq!(Discriminant::Boxed, discriminant);
 
         let boxed = BoxedString::from_str(32, "welp");
-        let discriminant = Discriminant::from_bit(BoxedString::check_alignment(&boxed));
+        let discriminant = SmartString::<Compact>::from_boxed(boxed).discriminant();
         assert_eq!(Discriminant::Boxed, discriminant);
 
         let mut s = SmartString::<Compact>::new();

--- a/src/test.rs
+++ b/src/test.rs
@@ -555,10 +555,10 @@ mod tests {
     #[test]
     fn check_sizes() {
         assert_eq!(core::mem::size_of::<SmartString<Compact>>(), core::mem::size_of::<String>());
-        // assert_eq!(core::mem::size_of::<Option<SmartString<Compact>>>(), core::mem::size_of::<Option<String>>());
+        assert_eq!(core::mem::size_of::<Option<SmartString<Compact>>>(), core::mem::size_of::<Option<String>>());
 
         assert_eq!(core::mem::size_of::<SmartString<LazyCompact>>(), core::mem::size_of::<String>());
-        // assert_eq!(core::mem::size_of::<Option<SmartString<LazyCompact>>>(), core::mem::size_of::<Option<String>>());
+        assert_eq!(core::mem::size_of::<Option<SmartString<LazyCompact>>>(), core::mem::size_of::<Option<String>>());
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -559,6 +559,64 @@ mod tests {
 
         assert_eq!(core::mem::size_of::<SmartString<LazyCompact>>(), core::mem::size_of::<String>());
         assert_eq!(core::mem::size_of::<Option<SmartString<LazyCompact>>>(), core::mem::size_of::<Option<String>>());
+
+        // -------------------------
+
+        let mut empty_bucket: Vec<Option<SmartString<Compact>>> = vec![];
+        let mut short_bucket: Vec<Option<SmartString<Compact>>> = vec![];
+        let mut long_bucket: Vec<Option<SmartString<Compact>>> = vec![];
+        let mut none_bucket: Vec<Option<SmartString<Compact>>> = vec![];
+
+        // make sure we shift around the allocation addresses by doing multiple of them and keeping the results
+        for _ in 0..1024 {
+            empty_bucket.push(Some(SmartString::new()));
+            empty_bucket.push(Some(SmartString::from("")));
+            short_bucket.push(Some(SmartString::from("hello")));
+            long_bucket.push(Some(SmartString::from("this is a really long line of text that will not be able to be inlined")));
+            none_bucket.push(None);
+        }
+
+        for v in empty_bucket {
+            assert_eq!(v.unwrap().as_str(), "");
+        }
+        for v in short_bucket {
+            assert_eq!(v.unwrap().as_str(), "hello");
+        }
+        for v in long_bucket {
+            assert_eq!(v.unwrap().as_str(), "this is a really long line of text that will not be able to be inlined");
+        }
+        for v in none_bucket {
+            assert!(v.is_none());
+        }
+
+        // -------------------------
+
+        let mut empty_bucket: Vec<Option<SmartString<LazyCompact>>> = vec![];
+        let mut short_bucket: Vec<Option<SmartString<LazyCompact>>> = vec![];
+        let mut long_bucket: Vec<Option<SmartString<LazyCompact>>> = vec![];
+        let mut none_bucket: Vec<Option<SmartString<LazyCompact>>> = vec![];
+
+        // make sure we shift around the allocation addresses by doing multiple of them and keeping the results
+        for _ in 0..1024 {
+            empty_bucket.push(Some(SmartString::new()));
+            empty_bucket.push(Some(SmartString::from("")));
+            short_bucket.push(Some(SmartString::from("hello")));
+            long_bucket.push(Some(SmartString::from("this is a really long line of text that will not be able to be inlined")));
+            none_bucket.push(None);
+        }
+
+        for v in empty_bucket {
+            assert_eq!(v.unwrap().as_str(), "");
+        }
+        for v in short_bucket {
+            assert_eq!(v.unwrap().as_str(), "hello");
+        }
+        for v in long_bucket {
+            assert_eq!(v.unwrap().as_str(), "this is a really long line of text that will not be able to be inlined");
+        }
+        for v in none_bucket {
+            assert!(v.is_none());
+        }
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -553,6 +553,15 @@ mod tests {
     }
 
     #[test]
+    fn check_sizes() {
+        assert_eq!(core::mem::size_of::<SmartString<Compact>>(), core::mem::size_of::<String>());
+        // assert_eq!(core::mem::size_of::<Option<SmartString<Compact>>>(), core::mem::size_of::<Option<String>>());
+
+        assert_eq!(core::mem::size_of::<SmartString<LazyCompact>>(), core::mem::size_of::<String>());
+        // assert_eq!(core::mem::size_of::<Option<SmartString<LazyCompact>>>(), core::mem::size_of::<Option<String>>());
+    }
+
+    #[test]
     fn from_string() {
         let std_s =
             String::from("I am a teapot short and stout; here is my handle, here is my snout");


### PR DESCRIPTION
Closes #47.

As far as I can tell, there was no real need to use `MaybeUninit<InlineString>` instead of just `InlineString` directly, due to it being a POD type. All that was required was changing the types of pointer casts we do to directly use `&self.data as *const _` rather than `self.data.as_ptr()` in various places.

Due to no longer using the `MaybeUninit` union type, we are able to get `Option` size optimization out of the `InlineString`. To do this, I changed `Marker(u8)` to `Marker(NonZeroU8)` and  changed it to use the low 2 bits for storing both the discriminant (as it already did), and also a non-zero bit to guarantee the requirement of `NonZeroU8`. I've also changed the allocator alignment requirement to 4 instead of 2 to guarantee these bits are free to use; this should not cause issues on 32 or 64 bit systems, which are our targets.

To ensure that a `BoxedString` write over the memory of the `InlineString` does not violate the requirements of `NonZeroU8` (and/or produce a `None` value), the `ptr` field in `BoxedString` was changed to a new `TaggedPtr` type that automatically handles setting the low 2 bits appropriately (and removing them when queried).

I feel that additional testing should be done, but it currently passes all existing test cases and a few that I added specifically about size requirements and `Some` vs `None` checks for small and large strings.